### PR TITLE
Get useful completion with . - _ delimiters...

### DIFF
--- a/zshrc.ohmyzsh
+++ b/zshrc.ohmyzsh
@@ -135,3 +135,6 @@ update-machine-config(){
 }
 
 eval "$(rbenv init - --no-rehash)"
+
+# Get useful completion with . - _ delimiters...
+zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'


### PR DESCRIPTION
if you have a path with `-`, `_` or `.` it's nice to be able to complete on it with these delimiters...

For example, if I have path filename `my-filename.storage` being able to complete it with`m-f.s` <kbd>TAB</kbd> is very handy.

This commit patches the `zshrc` to allow these chars to act as wildcards.